### PR TITLE
Add Check: only ASCII chars

### DIFF
--- a/ispconfig3_pass/config/config.inc.php.dist
+++ b/ispconfig3_pass/config/config.inc.php.dist
@@ -5,3 +5,4 @@ $config['password_check_symbol'] = true;
 $config['password_check_lower'] = true;
 $config['password_check_upper'] = true;
 $config['password_check_number'] = true;
+$config['password_check_isascii'] = true;

--- a/ispconfig3_pass/ispconfig3_pass.php
+++ b/ispconfig3_pass/ispconfig3_pass.php
@@ -56,6 +56,7 @@ class ispconfig3_pass extends rcube_plugin
             $checkLower = $this->rcmail->config->get('password_check_lower');
             $checkSymbol = $this->rcmail->config->get('password_check_symbol');
             $checkNumber = $this->rcmail->config->get('password_check_number');
+            $checkIsAscii = $this->rcmail->config->get('password_check_isascii');
             $error = false;
 
             if (!empty($pwl)) {
@@ -92,6 +93,11 @@ class ispconfig3_pass extends rcube_plugin
                 if (!$error && $checkSymbol && !preg_match("#\W+#", $newpwd)) {
                     $error = true;
                     $this->rcmail->output->command('display_message', $this->gettext('passwordchecksymbol'), 'error');
+                }
+
+                if (!$error && $checkIsAscii && preg_match("/[^\x20-\x7F]/", $newpwd)) {
+                    $error = true;
+                    $this->rcmail->output->command('display_message', $this->gettext('passwordcheckisascii'), 'error');
                 }
 
                 if (!$error) {

--- a/ispconfig3_pass/localization/bg_BG.inc
+++ b/ispconfig3_pass/localization/bg_BG.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Новата парола трябва да 
 $messages['passwordchecklower'] = 'Новата парола трябва да съдържа поне една малка буква.';
 $messages['passwordcheckupper'] = 'Новата парола трябва да съдържа поне една ГОЛЯМА буква.';
 $messages['passwordchecksymbol'] = 'Новата парола трябва да съдържа поне един специ@лен симол.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/cs_CZ.inc
+++ b/ispconfig3_pass/localization/cs_CZ.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Heslo musí obsahovat alespoň jedno číslo
 $messages['passwordchecklower'] = 'Heslo musí obsahovat alespoň jedno malé písmeno.';
 $messages['passwordcheckupper'] = 'Heslo musí obsahovat alespoň jedno velké písmeno.';
 $messages['passwordchecksymbol'] = 'Heslo musí obsahovat alespoň jeden symbol.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/da_DK.inc
+++ b/ispconfig3_pass/localization/da_DK.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Adgangskode skal indeholde mindst ét tal.';
 $messages['passwordchecklower'] = 'Adgangskode skal indeholde mindst ét stort bogstav.';
 $messages['passwordcheckupper'] = 'Adgangskode skal indeholde mindst ét lille bogstav.';
 $messages['passwordchecksymbol'] = 'Adgangskode skal indeholde mindst ét symbol.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/de_DE.inc
+++ b/ispconfig3_pass/localization/de_DE.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Das Passwort muss mindestens eine Zahl entha
 $messages['passwordchecklower'] = 'Das Passwort muss mindestens einen Kleinbuchstaben enthalten.';
 $messages['passwordcheckupper'] = 'Das Passwort muss mindestens einen Großbuchstaben enthalten.';
 $messages['passwordchecksymbol'] = 'Das Passwort muss mindestens ein Symbol enthalten.';
+$messages['passwordcheckisascii'] = 'Bitte verwenden Sie keine Umlaute im Passwort. Dies kann zu Problemen mit Ihrem E-Mail-Programm führen.';

--- a/ispconfig3_pass/localization/en_US.inc
+++ b/ispconfig3_pass/localization/en_US.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Password must include at least one number.';
 $messages['passwordchecklower'] = 'Password must include at least one lowercase letter.';
 $messages['passwordcheckupper'] = 'Password must include at least one uppercase letter.';
 $messages['passwordchecksymbol'] = 'Password must include at least one symbol.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/es_ES.inc
+++ b/ispconfig3_pass/localization/es_ES.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'La contraseña debe incluir al menos un núm
 $messages['passwordchecklower'] = 'La contraseña debe incluir al menos una minúscula.';
 $messages['passwordcheckupper'] = 'La contraseña debe incluir al menos una mayúscula.';
 $messages['passwordchecksymbol'] = 'La contraseña debe incluir al menos un símbolo.';
+$messages['passwordcheckisascii'] = 'Por favor, no use caracteres unicode especiales en su contraseña. Esto puede conllevar a errores en su cliente de correo.';

--- a/ispconfig3_pass/localization/fi_FI.inc
+++ b/ispconfig3_pass/localization/fi_FI.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Salasanassa täytyy olla vähintään yksi n
 $messages['passwordchecklower'] = 'Salasanassa täytyy olla vähintään yksi pieni kirjain';
 $messages['passwordcheckupper'] = 'Salasanassa täytyy olla vähintään yksi iso kirjain';
 $messages['passwordchecksymbol'] = 'Salasanassa täytyy olla vähintään yksi erikoismerkki';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/fr_FR.inc
+++ b/ispconfig3_pass/localization/fr_FR.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Le mot de passe doit inclure au moins un nom
 $messages['passwordchecklower'] = 'Le mot de passe doit inclure au moins une minuscule.';
 $messages['passwordcheckupper'] = 'Le mot de passe doit inclure au moins une majuscule.';
 $messages['passwordchecksymbol'] = 'Le mot de passe doit inclure au moins un caractère spécial.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/gl_ES.inc
+++ b/ispconfig3_pass/localization/gl_ES.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'O contrasinal debe incluír polo menos un n�
 $messages['passwordchecklower'] = 'O contrasinal debe incluír polo menos unha minúscula.';
 $messages['passwordcheckupper'] = 'O contrasinal debe incluír polo menos unha maiúscula.';
 $messages['passwordchecksymbol'] = 'O contrasinal debe incluir polo menos un símbolo.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/hu_HU.inc
+++ b/ispconfig3_pass/localization/hu_HU.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'A jelszónak legalább egy számot kell tart
 $messages['passwordchecklower'] = 'A jelszónak legalább egy kisbetűt kell tartalmaznia.';
 $messages['passwordcheckupper'] = 'A jelszónak legalább egy nagybetűt kell tartalmaznia.';
 $messages['passwordchecksymbol'] = 'A jelszónak legalább egy szimbólumot kell tartalmaznia.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/it_IT.inc
+++ b/ispconfig3_pass/localization/it_IT.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'La password deve includere almeno un numero.
 $messages['passwordchecklower'] = 'La password deve includere almeno una minuscola.';
 $messages['passwordcheckupper'] = 'La password deve includere almeno una maiuscola.';
 $messages['passwordchecksymbol'] = 'La password deve includere almeno un simbolo.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/lb_LU.inc
+++ b/ispconfig3_pass/localization/lb_LU.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'D\'Passwuert muss mindestens eng Zuel enthal
 $messages['passwordchecklower'] = 'D\'Passwuert muss mindestens ee klenge Buschtaf enthalen.';
 $messages['passwordcheckupper'] = 'D\'Passwuert muss mindestens ee grousse Buschtaf enthalen.';
 $messages['passwordchecksymbol'] = 'D\'Passwuert muss mindestens ee Symbol enthalen.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/lv_LV.inc
+++ b/ispconfig3_pass/localization/lv_LV.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Parolei jāsatur vismaz viens cipars.';
 $messages['passwordchecklower'] = 'Parolei jāsatur vismaz viens mazais latīņu alfabēta burts.';
 $messages['passwordcheckupper'] = 'Parolei jāsatur vismaz viens lielais latīņu alfabēta burts.';
 $messages['passwordchecksymbol'] = 'Parolei jāsatur vismaz viens speciālais simbols.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/nl_NL.inc
+++ b/ispconfig3_pass/localization/nl_NL.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Wachtwoord moet op zijn minst een nummer bev
 $messages['passwordchecklower'] = 'Wachtwoord moet ten minste één kleine letter bevatten.';
 $messages['passwordcheckupper'] = 'Wachtwoord moet minstens één hoofdletter bevatten.';
 $messages['passwordchecksymbol'] = 'Wachtwoord moet ten minste één symbool bevatten.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/pl_PL.inc
+++ b/ispconfig3_pass/localization/pl_PL.inc
@@ -15,3 +15,4 @@ $messages['passwordcheckupper'] = 'Hasło musi zawierać co najmniej jedną wiel
 $messages['passwordchecksymbol'] = 'Hasło musi zawierać co najmniej jeden znak specjalny (jak . , - + ).';
 $messages['internalerror'] = 'Błąd bazy danych serwera. To może być niebezpieczne dla innych użytkowników. Proszę się skontaktować z administratorem systemu.';
 $messages['errorsaving'] = 'Nie można zapisać hasła w bazie danych. Proszę się skontaktować z administratorem systemu.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/pt_BR.inc
+++ b/ispconfig3_pass/localization/pt_BR.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Senha tem que incluir pelo menos um número.
 $messages['passwordchecklower'] = 'Senha deve incluir pelo menos uma minúscula.';
 $messages['passwordcheckupper'] = 'Senha deve incluir pelo menos uma maiúscula.';
 $messages['passwordchecksymbol'] = 'Senha deve incluir pelo menos um símbolo.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/ru_RU.inc
+++ b/ispconfig3_pass/localization/ru_RU.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Новый пароль должен сод�
 $messages['passwordchecklower'] = 'Новый пароль должен содержать по крайней мере одну маленькую букву.';
 $messages['passwordcheckupper'] = 'Новый пароль должен содержать по крайней мере одну заглавную букву.';
 $messages['passwordchecksymbol'] = 'Новый пароль должен содержать по крайней мере один спец-символ.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/sl_SI.inc
+++ b/ispconfig3_pass/localization/sl_SI.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Geslo mora vključevati vsaj eno številko.'
 $messages['passwordchecklower'] = 'Geslo mora vsebovati vsaj eno male črke.';
 $messages['passwordcheckupper'] = 'Geslo mora vsebovati vsaj eno veliko črko.';
 $messages['passwordchecksymbol'] = 'Geslo mora vsebovati vsaj en simbol.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/sv_SE.inc
+++ b/ispconfig3_pass/localization/sv_SE.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Lösenordet måste innehålla minst ett numm
 $messages['passwordchecklower'] = 'Lösenordet måste innehålla minst en små bokstav.';
 $messages['passwordcheckupper'] = 'Lösenordet måste innehålla minst en stor bokstav.';
 $messages['passwordchecksymbol'] = 'Lösenordet måste innehålla minst en symbol.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';

--- a/ispconfig3_pass/localization/uk_UA.inc
+++ b/ispconfig3_pass/localization/uk_UA.inc
@@ -13,3 +13,4 @@ $messages['passwordchecknumber'] = 'Пароль повинен містити �
 $messages['passwordchecklower'] = 'Пароль повинен містити принаймні одну малу літеру.';
 $messages['passwordcheckupper'] = 'Пароль повинен містити принаймні одну велику літеру.';
 $messages['passwordchecksymbol'] = 'Пароль повинен містити принаймні один символ.';
+$messages['passwordcheckisascii'] = 'Please do not use special unicode characters for your password. This could lead to problems with your mail client.';


### PR DESCRIPTION
Umlaut Chars may cause issues with mail clients.

this implements the `mail_password_onlyascii` setting.