### PR TITLE
Fix user lookup for getHost.

### DIFF
--- a/ispconfig3_autoselect/ispconfig3_autoselect.php
+++ b/ispconfig3_autoselect/ispconfig3_autoselect.php
@@ -73,7 +73,7 @@ class ispconfig3_autoselect extends rcube_plugin
             $mail_user = $this->soap->mail_user_get($session_id, ['login' => $user]);
             // Alternatively also search the email field, this can differ from the login field for legacy reasons
             if (empty($mail_user)) {
-                $mail_user = $this->soap->mail_user_get($session_id, ['email' => $this->rcmail->user->data['username']]);
+                $mail_user = $this->soap->mail_user_get($session_id, ['email' => $user]);
             }
 
             if (count($mail_user) == 1) {


### PR DESCRIPTION
In this early login stage the username is only available in $user

I noticed it in the logs as: `Trying to access array offset on value of type null in /usr/share/ispconfig3_roundcube/ispconfig3_autoselect/ispconfig3_autoselect.php on line 76`