### PR TITLE
Fix whitelist/blacklist priority select values

### DIFF
--- a/ispconfig3_wblist/ispconfig3_wblist.php
+++ b/ispconfig3_wblist/ispconfig3_wblist.php
@@ -263,7 +263,10 @@ class ispconfig3_wblist extends rcube_plugin
 
         $field_id = 'wblistpriority';
         $input_wblistpriority = new html_select(['name' => '_' . $field_id, 'id' => $field_id]);
-        $input_wblistpriority->add(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);
+        $input_wblistpriority->add(
+            ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+            ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+        );
         $table->add('title', html::label($field_id, rcube::Q($this->gettext('wblistpriority'))));
         $table->add('', $input_wblistpriority->show($wblist[0]['priority'] ?? ''));
 


### PR DESCRIPTION
This fixes an off-by-one issue in the whitelist/blacklist priority selector of the ispconfig3_wblist plugin.

Before this change, the priority dropdown displayed values 1–10 in Roundcube, but the submitted values were effectively 0–9. As a result:

selecting priority 1 in Roundcube saved priority 0 in ISPConfig
selecting priority 5 in Roundcube saved priority 4 in ISPConfig
selecting priority 10 in Roundcube saved priority 9 in ISPConfig

ISPConfig itself uses priorities 1–10, so the submitted values should match the displayed values.

Cause:
The priority select only defined display labels:

$input_wblistpriority->add(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']);

This appears to result in submitted option values 0–9.

Fix:
Pass explicit option values matching the labels:

$input_wblistpriority->add(
    ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
    ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
);

Tested with:

Debian 13
ISPConfig 3.3.1p1
Roundcube 1.6.16+dfsg-0+deb13u1
ispconfig3_roundcube current GitHub version

Test result:

selecting priority 5 in Roundcube now saves priority 5 in ISPConfig
selecting priority 10 in Roundcube now saves priority 10 in ISPConfig